### PR TITLE
Disable default-features in azalea dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,6 @@ dependencies = [
  "azalea-world",
  "bevy_app",
  "bevy_ecs",
- "bevy_log",
  "bevy_tasks",
  "bevy_time",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.82"
-azalea = { git = "https://github.com/azalea-rs/azalea" }
+azalea = { git = "https://github.com/azalea-rs/azalea", default-features = false }
 futures-util = "0.3.30"
 indicatif = "0.17.8"
 portpicker = "0.1.1"


### PR DESCRIPTION
When creating a custom tracing_subscriber, bevy_log will complain on starting the bot:

`2024-06-16T15:36:15.644997Z ERROR bevy_log: Could not set global logger and tracing subscriber as they are already set. Consider disabling LogPlugin.`

This can be fixed by using `default-features = false` on the azalea dependency. However this crate, causes azalea's log feature to get re-enabled by default.

I looked to fix it with a `patch`-Section in the Cargo.toml. But it seems it can't fix this and is not meant to, since features are strictly additive.