### PR TITLE
Update viaproxy to 3.3.0 (MC 1.21 support)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use tokio::{
 use tracing::{error, info};
 
 const VIAPROXY_DOWNLOAD_URL: &str =
-    "https://github.com/ViaVersion/ViaProxy/releases/download/v3.2.2/ViaProxy-3.2.2.jar";
+    "https://github.com/ViaVersion/ViaProxy/releases/download/v3.3.0/ViaProxy-3.3.0.jar";
 
 const JAVA_DOWNLOAD_URL: &str = "https://adoptium.net/installation/";
 


### PR DESCRIPTION
ViaProxy for the newest version just got released.

Makes viaproxy actually work again, since it couldn't translate MC 1.21 before (current supported on azalea master branch).