### PR TITLE
Fix Java version parsing and add some tests for it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,19 +217,21 @@ pub async fn try_find_java_version() -> Result<Option<Version>> {
         Err(_) => None, /* Java not found */
         Ok(output) => {
             let stderr = String::from_utf8(output.stderr).context("UTF-8")?;
-            let (major, mut minor_patch, _) =
-                regex_captures!(r"(\d+)(\.\d+\.\d+)?", &stderr).context("Regex")?;
-
-            if minor_patch.is_empty() {
-                minor_patch = "0.0";
-            }
-
-            let text = format!("{major}{minor_patch}");
-            let version = Version::parse(&text).context("Version")?;
-
-            Some(version)
+            Some(parse_java_version(&stderr)?)
         }
     })
+}
+
+fn parse_java_version(stderr: &str) -> Result<Version> {
+    // whole, first group, second group
+    let (_, major, mut minor_patch) =
+        regex_captures!(r"(\d+)(\.\d+\.\d+)?", stderr).context("Regex")?;
+    if minor_patch.is_empty() {
+        minor_patch = ".0.0";
+    }
+
+    let text = format!("{major}{minor_patch}");
+    Ok(Version::parse(&text)?)
 }
 
 /// # Try to find a free port and return the socket address
@@ -279,4 +281,39 @@ where
     pb.refresh()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_openjdk_ea() {
+        let stderr = "openjdk version \"24-ea\" 2025-03-18
+OpenJDK Runtime Environment (build 24-ea+29-3578)
+OpenJDK 64-Bit Server VM (build 24-ea+29-3578, mixed mode, sharing)"
+            .to_string();
+        let version = parse_java_version(&stderr).unwrap();
+        assert_eq!(version, Version::new(24, 0, 0));
+    }
+
+    #[test]
+    fn test_parse_openjdk_8() {
+        let stderr = "openjdk version \"1.8.0_432\"
+OpenJDK Runtime Environment (build 1.8.0_432-b05)
+OpenJDK 64-Bit Server VM (build 25.432-b05, mixed mode)"
+            .to_string();
+        let version = parse_java_version(&stderr).unwrap();
+        assert_eq!(version, Version::new(1, 8, 0));
+    }
+
+    #[test]
+    fn test_parse_openjdk_11() {
+        let stderr = "openjdk version \"11.0.25\" 2024-10-15
+OpenJDK Runtime Environment (build 11.0.25+9)
+OpenJDK 64-Bit Server VM (build 11.0.25+9, mixed mode)"
+            .to_string();
+        let version = parse_java_version(&stderr).unwrap();
+        assert_eq!(version, Version::new(11, 0, 25));
+    }
 }


### PR DESCRIPTION
The attempted fix in https://github.com/azalea-rs/azalea-viaversion/commit/357a0ca49d72b72778085bf6842329fcdcf21972 doesn't actually work, since regex_captures destructures to `(whole, first group, second group)`, and the first part was being treated as the major version (instead of the second part). This makes both the major and minor version be parsed as 24. This PR fixes that, moves the parsing code to a separate function, and adds a few tests for some Java versions I have installed.