### PR TITLE
Update for Azalea ecs-login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,19 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compat"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +154,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "azalea"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-auth",
  "azalea-block",
@@ -203,6 +191,7 @@ dependencies = [
 [[package]]
 name = "azalea-auth"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf",
  "azalea-crypto",
@@ -222,6 +211,7 @@ dependencies = [
 [[package]]
 name = "azalea-block"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-block-macros",
  "azalea-buf",
@@ -231,6 +221,7 @@ dependencies = [
 [[package]]
 name = "azalea-block-macros"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -240,6 +231,7 @@ dependencies = [
 [[package]]
 name = "azalea-brigadier"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -249,6 +241,7 @@ dependencies = [
 [[package]]
 name = "azalea-buf"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf-macros",
  "byteorder",
@@ -262,6 +255,7 @@ dependencies = [
 [[package]]
 name = "azalea-buf-macros"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -271,6 +265,7 @@ dependencies = [
 [[package]]
 name = "azalea-chat"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf",
  "azalea-language",
@@ -284,8 +279,8 @@ dependencies = [
 [[package]]
 name = "azalea-client"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
- "async-compat",
  "azalea-auth",
  "azalea-block",
  "azalea-buf",
@@ -318,6 +313,7 @@ dependencies = [
 [[package]]
 name = "azalea-core"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -334,6 +330,7 @@ dependencies = [
 [[package]]
 name = "azalea-crypto"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "aes",
  "azalea-buf",
@@ -350,6 +347,7 @@ dependencies = [
 [[package]]
 name = "azalea-entity"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-block",
  "azalea-buf",
@@ -373,6 +371,7 @@ dependencies = [
 [[package]]
 name = "azalea-inventory"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -388,6 +387,7 @@ dependencies = [
 [[package]]
 name = "azalea-inventory-macros"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -397,6 +397,7 @@ dependencies = [
 [[package]]
 name = "azalea-language"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "compact_str",
  "serde",
@@ -406,6 +407,7 @@ dependencies = [
 [[package]]
 name = "azalea-physics"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-block",
  "azalea-core",
@@ -422,6 +424,7 @@ dependencies = [
 [[package]]
 name = "azalea-protocol"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "async-recursion",
  "azalea-auth",
@@ -456,6 +459,7 @@ dependencies = [
 [[package]]
 name = "azalea-protocol-macros"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -465,6 +469,7 @@ dependencies = [
 [[package]]
 name = "azalea-registry"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-buf",
  "azalea-registry-macros",
@@ -475,6 +480,7 @@ dependencies = [
 [[package]]
 name = "azalea-registry-macros"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "quote",
  "syn",
@@ -501,6 +507,7 @@ dependencies = [
 [[package]]
 name = "azalea-world"
 version = "0.11.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
 dependencies = [
  "azalea-block",
  "azalea-buf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayvec"
@@ -102,6 +102,19 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -153,8 +166,8 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "azalea"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-auth",
  "azalea-block",
@@ -190,8 +203,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-auth"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf",
  "azalea-crypto",
@@ -210,8 +223,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-block"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-block-macros",
  "azalea-buf",
@@ -220,8 +233,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-block-macros"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -230,8 +243,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-brigadier"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -240,8 +253,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-buf"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf-macros",
  "byteorder",
@@ -254,8 +267,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-buf-macros"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -264,8 +277,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-chat"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf",
  "azalea-language",
@@ -278,9 +291,10 @@ dependencies = [
 
 [[package]]
 name = "azalea-client"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
+ "async-compat",
  "azalea-auth",
  "azalea-block",
  "azalea-buf",
@@ -312,8 +326,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-core"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -329,8 +343,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-crypto"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "aes",
  "azalea-buf",
@@ -346,8 +360,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-entity"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-block",
  "azalea-buf",
@@ -370,8 +384,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-inventory"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -386,8 +400,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-inventory-macros"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -396,8 +410,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-language"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "compact_str",
  "serde",
@@ -406,8 +420,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-physics"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-block",
  "azalea-core",
@@ -423,8 +437,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-protocol"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "async-recursion",
  "azalea-auth",
@@ -458,8 +472,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-protocol-macros"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -468,8 +482,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-registry"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-buf",
  "azalea-registry-macros",
@@ -479,8 +493,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-registry-macros"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "quote",
  "syn",
@@ -506,8 +520,8 @@ dependencies = [
 
 [[package]]
 name = "azalea-world"
-version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#913d6ac8c52aa41305749e0a526f77079c84ecea"
+version = "0.12.0+mc1.21.5"
+source = "git+https://github.com/azalea-rs/azalea#3f60bdadac1a02e1109148bbbe5a8a3545f13849"
 dependencies = [
  "azalea-block",
  "azalea-buf",
@@ -797,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -867,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -944,10 +958,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.14"
+name = "critical-section"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -976,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
 dependencies = [
  "nix",
  "windows-sys 0.59.0",
@@ -986,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der"
@@ -1112,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1161,9 +1190,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -1288,6 +1317,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,12 +1403,14 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "6d844af74f7b799e41c78221be863bade11c430d46042c3b49ca8ae0c6d27287"
 dependencies = [
+ "async-recursion",
  "async-trait",
  "cfg-if",
+ "critical-section",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -1375,8 +1419,9 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "rand 0.9.1",
+ "ring",
+ "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1385,19 +1430,19 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "a128410b38d6f931fcc6ca5c107a3b02cabd6c05967841269a4ad65d23c44331"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-proto",
- "lru-cache",
+ "moka",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.9.1",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -1640,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1732,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -1754,24 +1799,18 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
 dependencies = [
  "zlib-rs",
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1796,12 +1835,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
+name = "loom"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "linked-hash-map",
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1849,9 +1892,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1865,6 +1908,25 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -2026,6 +2088,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "overload"
@@ -2147,6 +2213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2167,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2202,7 +2274,7 @@ checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2256,13 +2328,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2305,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -2476,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -2489,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "ring",
@@ -2541,6 +2612,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2717,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol_str"
@@ -2821,6 +2898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,9 +2999,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3338,6 +3421,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,9 +3477,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3361,6 +3498,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3520,9 +3667,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -3663,6 +3810,6 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,7 +167,6 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "azalea"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-auth",
  "azalea-block",
@@ -191,7 +203,6 @@ dependencies = [
 [[package]]
 name = "azalea-auth"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf",
  "azalea-crypto",
@@ -211,7 +222,6 @@ dependencies = [
 [[package]]
 name = "azalea-block"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-block-macros",
  "azalea-buf",
@@ -221,7 +231,6 @@ dependencies = [
 [[package]]
 name = "azalea-block-macros"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -231,7 +240,6 @@ dependencies = [
 [[package]]
 name = "azalea-brigadier"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -241,7 +249,6 @@ dependencies = [
 [[package]]
 name = "azalea-buf"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf-macros",
  "byteorder",
@@ -255,7 +262,6 @@ dependencies = [
 [[package]]
 name = "azalea-buf-macros"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -265,7 +271,6 @@ dependencies = [
 [[package]]
 name = "azalea-chat"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf",
  "azalea-language",
@@ -279,8 +284,8 @@ dependencies = [
 [[package]]
 name = "azalea-client"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
+ "async-compat",
  "azalea-auth",
  "azalea-block",
  "azalea-buf",
@@ -313,7 +318,6 @@ dependencies = [
 [[package]]
 name = "azalea-core"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -330,7 +334,6 @@ dependencies = [
 [[package]]
 name = "azalea-crypto"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "aes",
  "azalea-buf",
@@ -347,7 +350,6 @@ dependencies = [
 [[package]]
 name = "azalea-entity"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-block",
  "azalea-buf",
@@ -371,7 +373,6 @@ dependencies = [
 [[package]]
 name = "azalea-inventory"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf",
  "azalea-chat",
@@ -387,7 +388,6 @@ dependencies = [
 [[package]]
 name = "azalea-inventory-macros"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -397,7 +397,6 @@ dependencies = [
 [[package]]
 name = "azalea-language"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "compact_str",
  "serde",
@@ -407,7 +406,6 @@ dependencies = [
 [[package]]
 name = "azalea-physics"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-block",
  "azalea-core",
@@ -424,7 +422,6 @@ dependencies = [
 [[package]]
 name = "azalea-protocol"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "async-recursion",
  "azalea-auth",
@@ -459,7 +456,6 @@ dependencies = [
 [[package]]
 name = "azalea-protocol-macros"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -469,7 +465,6 @@ dependencies = [
 [[package]]
 name = "azalea-registry"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-buf",
  "azalea-registry-macros",
@@ -480,7 +475,6 @@ dependencies = [
 [[package]]
 name = "azalea-registry-macros"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "quote",
  "syn",
@@ -492,6 +486,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "azalea",
+ "bevy_tasks",
  "futures-util",
  "kdam",
  "lazy-regex",
@@ -506,7 +501,6 @@ dependencies = [
 [[package]]
 name = "azalea-world"
 version = "0.11.0+mc1.21.5"
-source = "git+https://github.com/azalea-rs/azalea#635bed9fcb8ea4048922364c9b5d7d1ee8b20063"
 dependencies = [
  "azalea-block",
  "azalea-buf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies]
 anyhow = "1.0"
-# azalea = { git = "https://github.com/azalea-rs/azalea", default-features = false }
-azalea = { path = "../azalea/azalea", default-features = false }
+azalea = { git = "https://github.com/azalea-rs/azalea", default-features = false }
 bevy_tasks = "0.15.3"
 futures-util = "0.3"
 kdam = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies]
 anyhow = "1.0"
-azalea = { git = "https://github.com/azalea-rs/azalea", default-features = false }
+# azalea = { git = "https://github.com/azalea-rs/azalea", default-features = false }
+azalea = { path = "../azalea/azalea", default-features = false }
+bevy_tasks = "0.15.3"
 futures-util = "0.3"
 kdam = "0.6"
 lazy-regex = "3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ reqwest = { version = "0.12", default-features = false, features = [
   "stream",
 ] }
 semver = "1.0"
-tokio = { version = "1.44", features = ["process"] }
+tokio = { version = "1.44.2", features = ["process"] }
 tracing = "0.1"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,0 +1,82 @@
+//! A swarm bot that allows you to modify the accounts being used and the target version and the server address from the CLI.
+//!
+//! Example usage:
+//! cargo r -r --example cli -- --account bot --server localhost --version 1.21.5
+
+use std::{env, process, time::Duration};
+
+use azalea::{prelude::*, swarm::SwarmBuilder};
+use azalea_viaversion::ViaVersionPlugin;
+
+#[tokio::main]
+async fn main() {
+    let args = parse_args();
+
+    tracing_subscriber::fmt::init();
+
+    let mut builder = SwarmBuilder::new();
+
+    for username_or_email in &args.accounts {
+        let account = if username_or_email.contains('@') {
+            Account::microsoft(username_or_email).await.unwrap()
+        } else {
+            Account::offline(username_or_email)
+        };
+
+        builder = builder.add_account(account);
+    }
+
+    let plugin = ViaVersionPlugin::start(args.version).await;
+
+    builder
+        .add_plugins(plugin)
+        .join_delay(Duration::from_millis(100))
+        .start(args.server)
+        .await
+        .unwrap();
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Args {
+    pub accounts: Vec<String>,
+    pub server: String,
+    pub version: String,
+}
+
+fn parse_args() -> Args {
+    let mut accounts = Vec::new();
+    let mut server = "localhost".to_string();
+    // default to the latest version
+    let mut version = azalea::protocol::packets::VERSION_NAME.to_string();
+
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--account" | "-A" => {
+                for account in args.next().expect("Missing account").split(',') {
+                    accounts.push(account.to_string());
+                }
+            }
+            "--server" | "-S" => {
+                server = args.next().expect("Missing server address");
+            }
+            "--version" | "-V" => {
+                version = args.next().expect("Missing version");
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", arg);
+                process::exit(1);
+            }
+        }
+    }
+
+    if accounts.is_empty() {
+        accounts.push("azalea".to_string());
+    }
+
+    Args {
+        accounts,
+        server,
+        version,
+    }
+}

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -27,7 +27,7 @@ async fn handle(bot: Client, event: Event, _: NoState) -> anyhow::Result<()> {
             // Split the message into the sender and message content
             let (sender, message) = message.split_sender_and_content();
             // If the sender is not the bot, repeat the message
-            if sender.is_none_or(|sender| sender != bot.profile.name) {
+            if sender.is_none_or(|sender| sender != bot.username()) {
                 bot.chat(&message);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use tokio::{
     net::TcpListener,
     process::Command,
 };
-use tracing::{error, trace};
+use tracing::{error, trace, warn};
 
 const JAVA_DOWNLOAD_URL: &str = "https://adoptium.net/installation";
 const VIA_OAUTH_VERSION: Version = Version::new(1, 0, 2);
@@ -180,7 +180,7 @@ impl ViaVersionPlugin {
             event.disabled = true;
 
             let Some(access_token) = &account.access_token else {
-                error!("Server is online-mode, but our account is offline-mode");
+                warn!("The server tried to make us authenticate, but our account is offline-mode");
                 commands.trigger(SendLoginPacketEvent::new(
                     event.entity,
                     build_custom_query_answer(event.packet.transaction_id, true),


### PR DESCRIPTION
Updates azalea-viaversion to work with this update: https://github.com/azalea-rs/azalea/pull/213

Also introduces a new `cli` example to make it slightly easier to test azalea-viaversion.