### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use tracing::{error, trace, warn};
 const JAVA_DOWNLOAD_URL: &str = "https://adoptium.net/installation";
 const VIA_OAUTH_VERSION: Version = Version::new(1, 0, 2);
 // https://github.com/ViaVersion/ViaProxy/releases
-const VIA_PROXY_VERSION: Version = Version::new(3, 4, 7);
+const VIA_PROXY_VERSION: Version = Version::new(3, 4, 8);
 
 #[derive(Clone, Resource)]
 pub struct ViaVersionPlugin {


### PR DESCRIPTION
Fixes this:
```
2026-01-03T15:16:01.944139Z  WARN azalea_viaversion: [18:16:01] [ForkJoinPool.commonPool-worker-1/WARN] (ViaProxy) You are running an outdated version of ViaProxy! Latest version: 3.4.8
```